### PR TITLE
Add Twitter proxy websites to intent filter

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,9 @@
                 <data android:host="twitter.com" />
                 <data android:host="mobile.twitter.com" />
                 <data android:host="x.com" />
+                <data android:host="vxtwitter.com" />
+                <data android:host="fxtwitter.com" />
+                <data android:host="fixupx.com" />
             </intent-filter>
 
             <intent-filter>


### PR DESCRIPTION
Those three are commonly used across Discord and Telegram to show embeds properly and redirect to Twitter, so it would be nice to also redirect them to Nitter